### PR TITLE
Remove myself

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ in advance. You can find the dates/times for future meetings on the Node.js [cal
 - [@ahmadawais](https://github.com/ahmadawais) - Ahmad Awais ⚡️
 - [@andrewhughes101](https://github.com/andrewhughes101) - Andrew Hughes
 - [@bengl](https://github.com/bengl) - Bryan English
-- [@benjamingr](https://github.com/benjamingr) - Benjamin Gruenbaum
 - [@BethGriggs](https://github.com/BethGriggs) - Bethany Nicolle Griggs
 - [@bmeck](https://github.com/bmeck) - Bradley Farias
 - [@bnb](https://github.com/bnb) - Tierney Cyren


### PR DESCRIPTION
Hey, unfortunately I was never active after the summit and I haven't had the capacity to be involved with the new baby and other work - removing myself from the team.

(Someone from the TSC or another leadership body would need to remove me from the actual team - while I am an org-admin because I'm a moderator we don't use moderation powers to do anything other than CoC violation handling)