### PR TITLE
chore: update branch name to main

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,4 +3,4 @@
 The Node.js project and its initiatives are committed to upholding the Node.js Code of Conduct.
 
 The Node.js Code of Conduct document can be found at
-https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
+https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md

--- a/meetings/2021-01-21.md
+++ b/meetings/2021-01-21.md
@@ -24,7 +24,7 @@
 ### nodejs/next-10
 
 * Needs/want of constituencies [#20](https://github.com/nodejs/next-10/issues/20)
-  * https://github.com/nodejs/next-10/blob/master/CONSTITUENCY-NEEDS.md is what we have landed.
+  * https://github.com/nodejs/next-10/blob/main/CONSTITUENCY-NEEDS.md is what we have landed.
   * How do we get confirmation that we get it right
     * survey
       * Which constituencies are part of?

--- a/meetings/2022-02-16.md
+++ b/meetings/2022-02-16.md
@@ -27,7 +27,7 @@
 ### nodejs/next-10
 
 * Summit recap and next steps - <https://github.com/nodejs/next-10/blob/main/meetings/summit-jan-2022.md>
-  * plan for modern http - <https://github.com/nodejs/node/blob/master/doc/contributing/maintaining-http.md>
+  * plan for modern http - <https://github.com/nodejs/node/blob/main/doc/contributing/maintaining-http.md>
     * Michael gave an overview, agreeing that with the doc capturing the strategy we are in a decent state on this front for modern http so only next step is to plan to revisit in 3 months or something like that.
     * Ruy asked about how we make sure collaborators are:
       * aware of the strategy and related docs
@@ -41,8 +41,8 @@
         (hopefully cross everybody versus breakout) + breakout sessions
   * Second session was on documentation
     * Concrete next steps
-      * PR into <https://github.com/nodejs/node/blob/master/tools/doc/README.md> for now that every method should have an example.
-      * PR into <https://github.com/nodejs/node/blob/master/tools/doc/README.md> - documentation for the metadata and how it is used. Michael will create issue in Next-10 to track that work - create issue to document metadata.
+      * PR into <https://github.com/nodejs/node/blob/main/tools/doc/README.md> for now that every method should have an example.
+      * PR into <https://github.com/nodejs/node/blob/main/tools/doc/README.md> - documentation for the metadata and how it is used. Michael will create issue in Next-10 to track that work - create issue to document metadata.
 
 * Beth should next-10 be a strategic initiative ?
   * Michael: makes sense to me. Lets do it.

--- a/meetings/2022-03-02.md
+++ b/meetings/2022-03-02.md
@@ -46,8 +46,8 @@
   * Review modern HTTP plan/progress
   * Baseline review (start with review of what we have, then whiteboard session to brainstorm
     additions/removals)
-    * <https://github.com/nodejs/node/blob/master/doc/contributing/technical-priorities.md>
-    * <https://github.com/nodejs/node/blob/master/doc/contributing/technical-values.md>
+    * <https://github.com/nodejs/node/blob/main/doc/contributing/technical-priorities.md>
+    * <https://github.com/nodejs/node/blob/main/doc/contributing/technical-values.md>
     * <https://github.com/nodejs/next-10/blob/main/CONSTITUENCIES.md>
     * <https://github.com/nodejs/next-10/blob/main/CONSTITUENCY-NEEDS.md>
   * Technical deep dives

--- a/meetings/summit-jan-2022.md
+++ b/meetings/summit-jan-2022.md
@@ -208,8 +208,8 @@ Client
     * <https://nodejs.org/en/docs/guides/>
   * Learning path
     * Learn (nodejs.dev) - <https://nodejs.dev/learn>
-  * Release Notes/Change logs <https://github.com/nodejs/node/tree/master/doc/changelogs>
-  * Internal documentation (contributing, etc) <https://github.com/nodejs/node/tree/master/doc>
+  * Release Notes/Change logs <https://github.com/nodejs/node/tree/main/doc/changelogs>
+  * Internal documentation (contributing, etc) <https://github.com/nodejs/node/tree/main/doc>
   * Roadmaps/efforts
   * Security model, processes etc.
   * Operations - Observability/tracing/monitoring
@@ -229,15 +229,15 @@ Client
 * Prioritization
   * Priority 1
     * API Documentation
-    * Release Notes/Change logs <https://github.com/nodejs/node/tree/master/doc/changelogs>
+    * Release Notes/Change logs <https://github.com/nodejs/node/tree/main/doc/changelogs>
 
   * Priority N
     * Guides (knowledge base), getting started, debugging, profiling etc.
     * <https://nodejs.org/en/docs/guides/>
   * Learning path
     * Learn (nodejs.dev) - <https://nodejs.dev/learn>
-  * Release Notes/Change logs <https://github.com/nodejs/node/tree/master/doc/changelogs>
-  * Internal documentation (contributing, etc) <https://github.com/nodejs/node/tree/master/doc>
+  * Release Notes/Change logs <https://github.com/nodejs/node/tree/main/doc/changelogs>
+  * Internal documentation (contributing, etc) <https://github.com/nodejs/node/tree/main/doc>
   * Roadmaps/efforts
   * Security model, processes etc.
   * Operations - Observability/tracing/monitoring

--- a/meetings/summit-nov-2021.md
+++ b/meetings/summit-nov-2021.md
@@ -91,7 +91,7 @@
 * Challenges with consuming existing data
   * Current JSON data is reasonably inaccurate, words
     are accurate, but struct is not. This function tries
-    to match things up - [github.com/SimonSchick/DefinitelyTyped/.../node-doc-processing.ts#L112](https://github.com/SimonSchick/DefinitelyTyped/blob/master/types/node/scripts/generate-docs/node-doc-processing.ts#L112)
+    to match things up - [github.com/SimonSchick/DefinitelyTyped/.../node-doc-processing.ts#L112](https://github.com/SimonSchick/DefinitelyTyped/blob/main/types/node/scripts/generate-docs/node-doc-processing.ts#L112)
   * Often generated JSON docs do not represent actual
     documentation.
   * How do we model complex generics overload?


### PR DESCRIPTION
GitHub does redirect to main, but made the changes as branch was renamed in nodejs/node