### PR TITLE
fix: link to removed file

### DIFF
--- a/meetings/2023-04-12.md
+++ b/meetings/2023-04-12.md
@@ -50,7 +50,7 @@
   * In the discussion of the API docs proposal the feeling was that translating the API docs is not a priority.
   * Jean would like to pursue
   * Jean will ping Nick from WebSite team has contributed to MDN to see if there is stats in terms of usage of different languages.
-  * Augustin mentioned some work by Alexendr tovmach on translation here - <https://github.com/nodejs/i18n/blob/main/script/collect.js>
+  * Augustin mentioned some work by Alexendr tovmach on translation here - <https://github.com/nodejs/i18n/blob/d4e590e836e682ef81c2fd19f7fa87856eb7ad8b/script/collect.js>
 
 * Next-10 next survey [#152](https://github.com/nodejs/next-10/issues/152)
   * Draft survey ready, deadline to review is this week I think.


### PR DESCRIPTION
In this meeting minute of 2023-04-12 we add a link to `collect.js` but this file as been remove just before archiving nodejs/i18n . So I add a correct link.